### PR TITLE
fix: windows icons bmWidthBytes 6 broke

### DIFF
--- a/src/windows/request.rs
+++ b/src/windows/request.rs
@@ -244,10 +244,15 @@ fn write_icon_data_to_memory(mem: &mut [u8], h_bitmap: HBITMAP, bmp: &BITMAP, bi
             pos += bmp.bmWidthBytes as usize;
 
             // extend to a 32bit boundary (in the file) if necessary
-            if bmp.bmWidthBytes & 3 != 0 {
+            if bmp.bmWidthBytes % 3 == 0 {
                 let padding: [u8; 4] = [0; 4];
-                ptr::copy_nonoverlapping(padding.as_ptr(), mem[pos..].as_mut_ptr(), (4 - bmp.bmWidthBytes) as usize); 
-                pos += 4 - bmp.bmWidthBytes as usize;
+
+                // Next devisor of 4
+                let nd4 = |x: i32| (x + 3) & !3;
+
+                let amount_to_pad = (nd4(bmp.bmWidthBytes) - bmp.bmWidthBytes) as usize;
+                ptr::copy_nonoverlapping(padding.as_ptr(), mem[pos..].as_mut_ptr(), amount_to_pad); 
+                pos += amount_to_pad;
             }
         }
     }


### PR DESCRIPTION
I had an issue where the copy failed padding the bytes. It ended up doing `4 - 6` to usize and that went way out of memory bounds

Had the issue when trying to open a size 32 image from the VSCode application on Windows

Not sure if this is the best implementation of the trick maybe this is even better:

```rust
            // extend to a 32bit boundary (in the file) if necessary
            // Next devisor of 4
            let nd4 = |x: i32| (x + 3) & !3;
            let padding_amount = nd4(bmp.bmWidthBytes) - bmp.bmWidthBytes;
            if padding_amount  != 0 {
                let padding: [u8; 4] = [0; 4];
                ptr::copy_nonoverlapping(padding.as_ptr(), mem[pos..].as_mut_ptr(), padding_amount ); 
                pos += padding_amount ;
            }
```
But I'll leave that up to you.