### PR TITLE
fix windows error

### DIFF
--- a/src/windows/request.rs
+++ b/src/windows/request.rs
@@ -179,7 +179,8 @@ fn get_icon_from_ext(ext: &str, size: i32) -> HICON {
                     SHGFI_SMALLICON
                 },
         ) };
-        if !file_info.hIcon.is_invalid() {
+        let h_icon = file_info.hIcon;
+        if !h_icon.is_invalid() {
             break;
         } else {
             let millis = Duration::from_millis(30);


### PR DESCRIPTION
This PR fixes this error on windows:

```
reference to packed field is unaligned packed structs are only aligned by one byte, and many modern architectures penalize unaligned field accesses creating a misaligned reference is undefined behavior (even if that reference is never dereferenced) copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
```