### PR TITLE
fix: windows icons bmWidthBytes 6 broke

### DIFF
--- a/src/windows/request.rs
+++ b/src/windows/request.rs
@@ -237,6 +237,8 @@ fn write_icon_data_to_memory(mem: &mut [u8], h_bitmap: HBITMAP, bmp: &BITMAP, bi
         // towards the top of the bitmap. Also, the bitmaps are stored in packed
         // in memory - scanlines are NOT 32bit aligned, just 1-after-the-other
         let mut pos = 0;
+        let nd4 = |x: i32| (x + 3) & !3;
+        let amount_to_pad = (nd4(bmp.bmWidthBytes) - bmp.bmWidthBytes) as usize;
         for i in (0..bmp.bmHeight).rev() {
             // Write the bitmap scanline
             
@@ -244,10 +246,10 @@ fn write_icon_data_to_memory(mem: &mut [u8], h_bitmap: HBITMAP, bmp: &BITMAP, bi
             pos += bmp.bmWidthBytes as usize;
 
             // extend to a 32bit boundary (in the file) if necessary
-            if bmp.bmWidthBytes & 3 != 0 {
+            if amount_to_pad != 0 {
                 let padding: [u8; 4] = [0; 4];
-                ptr::copy_nonoverlapping(padding.as_ptr(), mem[pos..].as_mut_ptr(), (4 - bmp.bmWidthBytes) as usize); 
-                pos += 4 - bmp.bmWidthBytes as usize;
+                ptr::copy_nonoverlapping(padding.as_ptr(), mem[pos..].as_mut_ptr(), amount_to_pad); 
+                pos += amount_to_pad;
             }
         }
     }


### PR DESCRIPTION
2nd attempt to fix this

This is more based on my original idea I put forward in the MR but didn't implement.

The main issue with the previous pr #6 was that I changed the check `if bmp.bmWidthBytes & 3 != 0` to `if bmp.bmWidthBytes % 3 == 0` that was an error as it would cause to not pad in some cases.

But as we know the amount of bytes to pad is equal for each line in the image we're writing we can compute the amount to pad upfront and pad based on that every iteration in the loop if it's not 0. 

NB. My issues with getting the icon of VS Code (either from `%LOCALAPPDATA%\Programs\Microsoft VS Code\code.exe` or the system wide install location) didn't happen on display scaling 100% but only on 150%. Good you put out pointers regarding display scaling with your issues.